### PR TITLE
Power up spiders

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1302,6 +1302,13 @@
     interactSuccessString: petting-success-tarantula
     interactFailureString: petting-failure-generic
   - type: Puller
+  - type: MeleeWeapon
+    hidden: true
+    angle: 0
+    animation: WeaponArcBite
+    damage:
+      groups:
+        Brute: 12
 
 - type: entity
   name: tarantula


### PR DESCRIPTION
повысить урон для гигантский пауков, ибо бесполезны, против уборщика с шваброй они сразу отлетают, да даже если робастить его умело, все равно очень мало наносит, это ещё должно повезти кого то найти, чтобы ты не заспавнился где то в техах, они даже шлюз сломать не могут нормально
by HankAnders https://discord.com/channels/727015266642296924/1037396123985379338/1054484939384561746

Урон повышен с 5 до 12. Так, чтобы дверь в техи выбивалась за 100 укусов. Больше делать не стал, т.к. может повлиять на баланс. 5 действительно было слишком мало.