### PR TITLE
Fix for pop ups

### DIFF
--- a/Content.Server/AruMoon/WoundLicking/WoundLickingSystem.cs
+++ b/Content.Server/AruMoon/WoundLicking/WoundLickingSystem.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Felinid
             if (performer == target & !woundLicking.CanSelfApply)
             {
                 _popupSystem.PopupEntity(Loc.GetString("lick-wounds-yourself-impossible"),
-                    performer, Filter.Entities(performer));
+                    performer, Filter.Entities(performer), true);
                 return;
             }
             
@@ -88,11 +88,11 @@ namespace Content.Server.Felinid
                 if (performer == target)
                 {
                     _popupSystem.PopupEntity(Loc.GetString("lick-wounds-yourself-no-wounds"),
-                        performer, Filter.Entities(performer));
+                        performer, performer);
                     return;
                 }
                 _popupSystem.PopupEntity(Loc.GetString("lick-wounds-performer-no-wounds", ("target", target)),
-                    performer, Filter.Entities(performer));
+                    performer, performer);
                 return;
             }
 
@@ -103,11 +103,11 @@ namespace Content.Server.Felinid
                 .RemoveWhereAttachedEntity(e => e == performer || e == target);
 
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-performer-begin", ("target", targetIdentity)),
-                performer, Filter.Entities(performer));
+                performer, performer);
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-target-begin", ("performer", performerIdentity)),
-                target, Filter.Entities(target));
+                target, target);
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-other-begin", ("performer", performerIdentity), ("target", targetIdentity)),
-                performer, otherFilter);
+                performer, otherFilter, true);
             
             // DoAfter
             woundLicking.CancelToken = new CancellationTokenSource();
@@ -164,11 +164,11 @@ namespace Content.Server.Felinid
                 .RemoveWhereAttachedEntity(e => e == performer || e == target);
 
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-performer-success", ("target", targetIdentity)),
-                performer, Filter.Entities(performer));
+                performer, performer);
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-target-success", ("performer", performerIdentity)),
-                target, Filter.Entities(target));
+                target, target);
             _popupSystem.PopupEntity(Loc.GetString("lick-wounds-other-success", ("performer", performerIdentity), ("target", targetIdentity)),
-                performer, otherFilter);
+                performer, otherFilter, true);
         }
     }
     

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -301,7 +301,7 @@ namespace Content.Server.Lathe
                 return;
             if (!_accessReaderSystem.IsAllowed(player, uid))
             {
-                ConsolePopup(args.Session, Loc.GetString("lathe-production-not-allowed"));
+                ConsolePopup(args.Session, uid, Loc.GetString("lathe-production-not-allowed"));
                 PlayDenySound(uid, component);
                 return;
             }
@@ -317,9 +317,9 @@ namespace Content.Server.Lathe
             UpdateUserInterfaceState(uid, component);
         }
 
-        private void ConsolePopup(ICommonSession session, string text)
+        private void ConsolePopup(ICommonSession session, EntityUid uid, string text)
         {
-            _popup.PopupCursor(text, session);
+            _popup.PopupEntity(text, uid, session);
         }
 
         private void PlayDenySound(EntityUid uid, LatheComponent component)

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -319,7 +319,7 @@ namespace Content.Server.Lathe
 
         private void ConsolePopup(ICommonSession session, string text)
         {
-            _popup.PopupCursor(text, Filter.SinglePlayer(session));
+            _popup.PopupCursor(text, session);
         }
 
         private void PlayDenySound(EntityUid uid, LatheComponent component)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Исправлены ошибки, которые связанные с поп апами, которые крашили компилятор :skull:
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:

