### PR TITLE
Drone interaction range removed

### DIFF
--- a/Content.Server/Drone/Components/DroneComponent.cs
+++ b/Content.Server/Drone/Components/DroneComponent.cs
@@ -3,9 +3,7 @@ namespace Content.Server.Drone.Components
     [RegisterComponent]
     public sealed class DroneComponent : Component
     {
-        public const float DefaultInteractionBlockRange = 2.15f;
-
         [ViewVariables(VVAccess.ReadWrite), DataField("interactionBlockRange")]
-        public float InteractionBlockRange { get; set; } = DefaultInteractionBlockRange;
+        public float InteractionBlockRange { get; set; } = 2.15f;
     }
 }

--- a/Content.Server/Drone/Components/DroneComponent.cs
+++ b/Content.Server/Drone/Components/DroneComponent.cs
@@ -3,6 +3,9 @@ namespace Content.Server.Drone.Components
     [RegisterComponent]
     public sealed class DroneComponent : Component
     {
-        public float InteractionBlockRange = 2.15f;
+        public const float DefaultInteractionBlockRange = 2.15f;
+
+        [ViewVariables(VVAccess.ReadWrite), DataField("interactionBlockRange")]
+        public float InteractionBlockRange { get; set; } = DefaultInteractionBlockRange;
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -70,6 +70,7 @@
   parent: PlayerSiliconBase
   components:
   - type: Drone
+    interactionBlockRange : 0.01
   - type: InnateTool
     tools:
       - id: ClothingBackpackSatchelDrone


### PR DESCRIPTION
Убрать ограничение дронам на существ поблизости. Они ничего не могут делать если кто-то рядом, а сказать они не могут. Ещё если лежит труп, они тоже ничего не могут делать и не могут его тоскать

by Gaming Dog (Юрий Одинцов) https://discord.com/channels/727015266642296924/1037396123985379338/1055417830805352538