### PR TITLE
Colored markings for felinids

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/felinid.yml
@@ -6,10 +6,16 @@
   speciesRestriction: [Felinid]
   coloring:
     default:
-      type: HairColor
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SkinColoring
     layers:
       ears_default_inner:
-        type: SimpleColor
+        type:
+          !type:SimpleColoring
+            color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/felinid.rsi
     state: ears_default_outer
@@ -23,10 +29,16 @@
   speciesRestriction: [Felinid]
   coloring:
     default:
-      type: HairColor
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SkinColoring
     layers:
       ears_static_inner:
-        type: SimpleColor
+        type:
+          !type:SimpleColoring
+            color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/felinid.rsi
     state: ears_static_outer
@@ -42,10 +54,13 @@
   speciesRestriction: [Felinid]
   coloring:
     default:
-      type: HairColor
-  sprites:
-  - sprite: Mobs/Customization/felinid.rsi
-    state: tail_default
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:CategoryColoring
+          category: FacialHair
+        - !type:SkinColoring
 
 - type: marking
   id: FelinidTailResprite
@@ -54,7 +69,13 @@
   speciesRestriction: [Felinid]
   coloring:
     default:
-      type: HairColor
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:CategoryColoring
+          category: FacialHair
+        - !type:SkinColoring
   sprites:
   - sprite: Mobs/Customization/felinid.rsi
     state: tail_resprite

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/felinid.yml
@@ -61,6 +61,9 @@
         - !type:CategoryColoring
           category: FacialHair
         - !type:SkinColoring
+  sprites:
+  - sprite: Mobs/Customization/felinid.rsi
+    state: tail_default
 
 - type: marking
   id: FelinidTailResprite
@@ -87,7 +90,13 @@
   speciesRestriction: [Felinid]
   coloring:
     default:
-      type: HairColor
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:CategoryColoring
+          category: FacialHair
+        - !type:SkinColoring
   sprites:
   - sprite: Mobs/Customization/felinid.rsi
     state: tail_static


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
**НЕ МЁРДЖИТЬ ПОКА НЕ БУДЕТ НУЖНОГО КОДА С АПСТРИМА**
  (ну или если мы его сами не добавим)
<details>
  <summary>Описание</summary>
  Красит уши и хвост фелинидов в цвет их волос. Если волос нету, то в цвет кожи.
</details>


**Media**

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Цвет хвостов и ушей у фелинидов теперь соответствует цвету их волос
