### PR TITLE
Демилитаризация РнД

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -204,3 +204,4 @@
       - id: RubberStampHos
       - id: SecurityTechFabCircuitboard
       - id: JetpackSecurityFilled
+      - id: WeaponTechFabCircuitboard

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -255,7 +255,6 @@
     - WeaponSubMachineGunWt550
     - WeaponRifleLecter
     - WeaponShotgunDoubleBarreled
-    - WeaponRifleAk
     - WeaponPistolMk58
     - WeaponSubMachineGunVector
 
@@ -273,7 +272,6 @@
   unlockedRecipes:
     - WeaponDisabler
     - WeaponLaserCarbine
-    - WeaponAdvancedLaser
 #
 # - type: technology
 #   name: "explosives technology"

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -330,8 +330,6 @@
       - APECircuitboard
       - ArtifactAnalyzerMachineCircuitboard
       - TraversalDistorterMachineCircuitboard
-      - SecurityTechFabCircuitboard
-      - WeaponTechFabCircuitboard
       - BoozeDispenserMachineCircuitboard
       - SodaDispenserMachineCircuitboard
   - type: MaterialStorage
@@ -507,13 +505,11 @@
       - WeaponSubMachineGunWt550
       - WeaponRifleLecter
       - WeaponShotgunDoubleBarreled
-      - WeaponRifleAk
       - WeaponPistolMk58
       - WeaponSubMachineGunVector
       # Weapons energy
       - WeaponDisabler
       - WeaponLaserCarbine
-      - WeaponAdvancedLaser
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -512,26 +512,6 @@
     Steel: 100
     Glass: 900
 
-# Security machinery
-- type: latheRecipe
-  id: WeaponTechFabCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: security }
-  result: WeaponTechFabCircuitboard
-  completetime: 4
-  materials:
-    Steel: 100
-    Glass: 900
-    Gold: 100
-
-- type: latheRecipe
-  id: SecurityTechFabCircuitboard
-  icon: { sprite: Objects/Misc/module.rsi, state: security }
-  result: SecurityTechFabCircuitboard
-  completetime: 4
-  materials:
-    Steel: 100
-    Glass: 900
-
 - type: latheRecipe
   id: BoozeDispenserMachineCircuitboard
   result: BoozeDispenserMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -323,17 +323,6 @@
     Steel: 500
 
 - type: latheRecipe
-  id: WeaponRifleAk
-  icon:
-    sprite: Objects/Weapons/Guns/Rifles/ak.rsi
-    state: base
-  result: WeaponRifleAk
-  completetime: 30
-  materials:
-    Wood: 200
-    Steel: 1000
-
-- type: latheRecipe
   id: WeaponPistolMk58
   icon:
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
@@ -388,18 +377,6 @@
     Glass: 500
     Plastic: 500
     Steel: 500
-
-- type: latheRecipe
-  id: WeaponAdvancedLaser
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
-    state: base
-  result: WeaponAdvancedLaser
-  completetime: 30
-  materials:
-    Gold: 1500
-    Steel: 500
-    Uranium: 500
 
 - type: latheRecipe
   id: MagazineBoxPistol


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Убирает рецепт секфаба и оружейного фаба из технологий РнД. Теперь плата оружейного фаба даётся только ХоСу

Убран рецепт калаша: Он больше относится к СССП чем к НТ, да и я очень скептично отношусь к его балансности ибо он нигде не используется в апстриме.
Убран рецепт улучшенного лазера: Буквально антиквар кэпа с другой текстуркой.

Что фиксит этот баланс:
- РнД и карго больше не будут самым сильным союзом на станции
- Карго больше не смогут производить пушки на продажу

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- remove: Удалены рецепты калаша и улучшенного лазера
- tweak: Карта оружейного фаба теперь есть только у ХоСа
