### PR TITLE
Вместительность халатов/курток 10 ->15

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -29,9 +29,9 @@
   id: ClothingOuterStorageBase
   components:
   - type: Item
-    size: 13
+    size: 15
   - type: Storage
-    capacity: 13
+    capacity: 15
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -29,9 +29,9 @@
   id: ClothingOuterStorageBase
   components:
   - type: Item
-    size: 10
+    size: 13
   - type: Storage
-    capacity: 10
+    capacity: 13
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
## About the PR
Теперь в халатах и куртках не 10 вместительности, а 15. Сделано это прежде всего для таблетниц (которые не помещаются в хранилища вместительностью 12 или меньше). Немного подумав, решение сделать вместительность 15, а не 13, показалось мне более подходящим.

**Changelog**
:cl:
- tweak: Вместительность халатов и курток изменена с 10 до 15
