### PR TITLE
disable ArrivalsShattle

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -295,7 +295,7 @@ public sealed class ArrivalsSystem : EntitySystem
     private void OnRoundStarting(RoundStartingEvent ev)
     {
         // Setup arrivals station
-        if (!Enabled)
+        if (Enabled)
             return;
 
         SetupArrivalsStation();


### PR DESCRIPTION
## О запросе слияния
Добавили очередную "очень продуманную" систему автор которой "точно ее тестировал".
Если в кратце, то шаттл прибытия, вылетающий со станции ожидания - может спокойно оставить игрока в космосе.

**Медиа**
![image](https://user-images.githubusercontent.com/95057024/227166555-fd06d713-91b7-4ba6-974a-60bbb51c6474.png)


**Чейнджлог**

:cl:
- remove: Убран шаттл и прибытия и станция ожидания