### PR TITLE
JetpackBlack can be equipt in suitStorage slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -114,6 +114,7 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
+      - suitStorage
 
 # Filled black
 - type: entity


### PR DESCRIPTION
## О запросе слияния
Этот джет есть только на базе нюкеров, одном обломке утилей и в аплинке за 4! тк. Джеты нюкеры обычно не берут ибо он занимает очень важный слот руки. Это изменение сделает более популярной тактику где нюки не стыкуют шаттл, а так-же сделает его покупку в аплинке оправданной.

**Чейнджлог**


:cl:
- tweak: Джетпак синдиката можно экипировать на слот хранилища скафандра.
