### PR TITLE
Главы вновь будут антагами (надеюсь)

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -14,7 +14,6 @@
   startingGear: QuartermasterGear
   icon: "QuarterMaster"
   supervisors: job-supervisors-hop
-  canBeAntag: false
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -14,7 +14,6 @@
   icon: "ChiefMedicalOfficer"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
-  canBeAntag: false
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -12,7 +12,6 @@
   icon: "ResearchDirector"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
-  canBeAntag: false
   access:
   - Research
   - Command


### PR DESCRIPTION
Ну и всё как бы.
Никто на глав-антагов в общем-то и не жаловался, но в связи с "особыми взглядами Визардов" один из коммитов им убрал возможность быть антагами. Чтож этот пр исправляет это недоразумение UwU
Вообще в коде как бы удаляется 3 строки (по 1 на главу (сделано по аналогии со всеми другими ролями (или `canBeAntag: false` есть или его нет ну и всё))), но т.к. в игре этого не видно, то это скорее твик, а не ремув.

**Медиа**
- [ ] тут ничего нет потому что нечего показывать. Это можно только прочувствовать непосредственно в игре.

**Чейнджлог**

:cl:
- tweak: Главный врач, Научный руководитель и Квартирмейстер вновь могут быть антагонистами.
