### PR TITLE
vending machines can be broken

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -35,10 +35,25 @@
     - trigger:
         !type:DamageTrigger
         damage: 100
+        triggersOnce: true
       behaviors:
       - !type:DoActsBehavior
         acts: ["Breakage"]
-      - !type:EjectVendorItems
+      - !type:EjectVendorItems      
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 3
   - type: ActivatableUI
     key: enum.VendingMachineUiKey.Key
   - type: ActivatableUIRequiresPower


### PR DESCRIPTION
## О запросе слияния
Прошаренные ребята берут раздатчики и разряжают в них турели нюки, ибо раздатчики не могут быть уничтожены (рис.1). С этим обновлением они так делать не смогут.


**Медиа**
![image](https://user-images.githubusercontent.com/95057024/231366115-24d8b769-a3ef-4dfe-a265-bc11491e3f2f.png)


- [X] Я добавил скриншоты/видео к этому запросу слияния, демонстрирующие его изменения в игре, **или** этот запрос слияния не требует демонстрации в игре

**Чейнджлог**


:cl:
- tweak: Материал из которого сделаны раздатчики больше не связан сильным взаимодействием.
