### PR TITLE
remove BallisticAmmoProvider from shutgun shell boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -334,13 +334,12 @@
       - id: MagazineShotgunIncendiary
         amount: 6
 
-# base BallisticAmmoProvider boxes
+# base Shotgun Shells container boxes
 - type: entity
   parent: BoxMagazine
   id: BoxAmmoProvider
   abstract: true
   components:
-  - type: BallisticAmmoProvider
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
@@ -353,9 +352,10 @@
   id: BoxBeanbag
   description: A box full of beanbag shots, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunBeanbag
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgunBeanbag
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -367,9 +367,10 @@
   id: BoxLethalshot
   description: A box full of lethal pellet shots, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgun
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgun
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -381,9 +382,10 @@
   id: BoxShotgunSlug
   description: A box full of shotgun slugs, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunSlug
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgunSlug
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -395,9 +397,10 @@
   id: BoxShotgunFlare
   description: A box full of shotgun flare cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunFlare
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgunFlare
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -409,9 +412,10 @@
   id: BoxShotgunIncendiary
   description: A box full of shotgun incendiary cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunIncendiary
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgunIncendiary
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -423,9 +427,10 @@
   id: BoxShotgunPractice
   description: A box full of shotgun practice cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellShotgunPractice
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellShotgunPractice
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide
@@ -437,9 +442,10 @@
   id: BoxShellTranquilizer
   description: A box full of tranquilizer cartridges, designed for riot shotguns.
   components:
-    - type: BallisticAmmoProvider
-      proto: ShellTranquilizer
-      capacity: 12
+    - type: StorageFill
+      contents:
+      - id: ShellTranquilizer
+        amount: 30
     - type: Sprite
       layers:
         - state: boxwide

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -161,8 +161,8 @@
     contents:
       - id: WeaponShotgunEnforcer
         amount: 2
-      - id: MagazineShotgun
-        amount: 4
+      - id: BoxLethalshot
+        amount: 2
 
 - type: entity
   id: GunSafeShotgunKammerer
@@ -174,8 +174,8 @@
     contents:
       - id: WeaponShotgunKammerer
         amount: 2
-      - id: MagazineShotgun
-        amount: 4
+      - id: BoxLethalshot
+        amount: 2
 
 - type: entity
   id: GunSafeSubMachineGunWt550


### PR DESCRIPTION
## О запросе слияния
Пули для дробовика больше не будут отправляться в войд при доставании их из коробок.

:cl:
- tweak: Изменены коробки с ружейными патронами
- tweak: Оружейые сейфы с дробовиками теперь содержат коробки с ружейными патронами, а не магазины для бульдога.
