### PR TITLE
Фикс инжекта реагентов при коллизии снарядов

### DIFF
--- a/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionInjectOnCollideComponent.cs
@@ -25,5 +25,11 @@ namespace Content.Server.Chemistry.Components
         /// </summary>
         [DataField("blockSlots"), ViewVariables(VVAccess.ReadWrite)]
         public SlotFlags BlockSlots = SlotFlags.MASK;
+        
+        /// <summary>
+        /// Fixture we track for the collision.
+        /// </summary>
+        [DataField("fixture")]
+        public string FixtureID = "projectile";
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnCollideSystem.cs
@@ -34,6 +34,8 @@ namespace Content.Server.Chemistry.EntitySystems
 
         private void HandleInjection(EntityUid uid, SolutionInjectOnCollideComponent component, ref StartCollideEvent args)
         {
+            if (args.OurFixture.ID != component.FixtureID) return;
+            
             var target = args.OtherFixture.Body.Owner;
 
             if (!args.OtherFixture.Body.Hard ||


### PR DESCRIPTION
## О запросе слияния
<!-- Что изменено? На какие вещи это может повлиять? -->
Теперь система для инжекта проджектайла при коллизии не будет инжектить реагенты, задевая какой-то рандомной фикстурой игроков

Это должно пофиксить магическую способность шприцемёта инжектить снаряды, при этом не задевая людей

**Медиа**
<!-- 
Запросы слияния, которые вносят внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), должны содержать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не требуют медиа.

Если Вы не уверены в том, что Ваш запрос слияния требует медиа, спросите мейнтейнера.

Отметьте поле ниже, чтобы подтвердить, что Вы действительно видели это (поставьте X в скобках, например [X]):
-->

https://github.com/Workbench-Team/space-station-14/assets/56765288/076905f6-4d29-4abb-9874-72f8cf917c67


- [x] Я добавил скриншоты/видео к этому запросу слияния, демонстрирующие его изменения в игре, **или** этот запрос слияния не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при слиянии Вашего запроса на слияние.

Вносите в журнал изменений только те изменения, которые заметны и важны для игрока.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->

:cl:
- fix: Снаряды шприцемёта теперь вводят реагенты только при прямом попадании по игроку
