### PR TITLE
AME, СМЕСы и подстанции теперь бьют током при атаке по ним

### DIFF
--- a/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
@@ -73,4 +73,7 @@ public sealed class ElectrifiedComponent : Component
 
     [DataField("shockVolume")]
     public float ShockVolume = 20;
+
+    [DataField("chanceOfShock"), ViewVariables(VVAccess.ReadWrite)]
+    public float ChanceOfShock = 1f;
 }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -156,19 +156,19 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             TryDoElectrifiedAct(uid, args.OtherFixture.Body.Owner, 1, electrified);
     }
 
-        private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
+    private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
+    {
+        if (!electrified.OnAttacked ||
+            !_random.Prob(electrified.ChanceOfShock)
+        )
+            return;
+        //Dont shock if the attacker used a toy
+        if (EntityManager.TryGetComponent<MeleeWeaponComponent>(args.Used, out var meleeWeaponComponent))
         {
-            if (!electrified.OnAttacked)
+            if (meleeWeaponComponent.Damage.Total == 0)
                 return;
-
-            //Dont shock if the attacker used a toy
-            if (EntityManager.TryGetComponent<MeleeWeaponComponent>(args.Used, out var meleeWeaponComponent))
-            {
-                if (meleeWeaponComponent.Damage.Total == 0)
-                    return;
-            }
-
-            TryDoElectrifiedAct(uid, args.User, 1, electrified);
+        }
+        TryDoElectrifiedAct(uid, args.User, 1, electrified);
     }
 
     private void OnElectrifiedHandInteract(EntityUid uid, ElectrifiedComponent electrified, InteractHandEvent args)

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -159,8 +159,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
     {
         if (!electrified.OnAttacked ||
-            !_random.Prob(electrified.ChanceOfShock)
-        )
+            !_random.Prob(electrified.ChanceOfShock))
             return;
         //Dont shock if the attacker used a toy
         if (EntityManager.TryGetComponent<MeleeWeaponComponent>(args.Used, out var meleeWeaponComponent))

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -46,6 +46,13 @@
       path: /Audio/Weapons/emitter.ogg
   - type: PowerConsumer
     voltage: Medium
+  - type: Electrified
+    onHandInteract: false
+    onInteractUsing: false
+    onBump: false
+    requirePower: true
+    mediumVoltageNode: input
+    chanceOfShock: 0.33
   - type: NodeContainer
     examinable: true
     nodes:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -57,6 +57,13 @@
       type: AMEControllerBoundUserInterface
   - type: Appearance
   - type: AMEControllerVisuals
+  - type: Electrified
+    onHandInteract: false
+    onInteractUsing: false
+    onBump: false
+    requirePower: true
+    highVoltageNode: input
+    chanceOfShock: 0.33
   - type: NodeContainer
     examinable: true
     nodes:

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -38,6 +38,13 @@
         output:
           !type:CableTerminalPortNode
           nodeGroupID: HVPower
+    - type: Electrified
+      onHandInteract: false
+      onInteractUsing: false
+      onBump: false
+      requirePower: true
+      highVoltageNode: output
+      chanceOfShock: 0.33
     - type: BatteryCharger
       voltage: High
       node: output

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -37,6 +37,14 @@
       output:
         !type:CableDeviceNode
         nodeGroupID: MVPower
+  - type: Electrified
+    onHandInteract: false
+    onInteractUsing: false
+    onBump: false
+    requirePower: true
+    mediumVoltageNode: output
+    highVoltageNode: input
+    chanceOfShock: 0.33
   - type: BatteryCharger
     voltage: High
   - type: BatteryDischarger


### PR DESCRIPTION
## О запросе слияния
<!-- Что изменено? На какие вещи это может повлиять? -->
С некоторым шансом, AME, СМЕСы, эмиттеры и подстанции будут бить током при ударе по ним. Теперь различные грызуны, например крысы-мутанты, не смогут сжирать их.

Это не будет препятствовать их разрушению для людей, ведь для предотвращения урона электричеством можно просто открутить объект

**Медиа**

https://github.com/Workbench-Team/space-station-14/assets/56765288/b26319f2-c873-4583-b138-5a89fc72621e

- [x] Я добавил скриншоты/видео к этому запросу слияния, демонстрирующие его изменения в игре, **или** этот запрос слияния не требует демонстрации в игре

**Чейнджлог**
:cl:
- tweak: СМЕС, АМЕ, подстанции и эмиттеры теперь иногда будут бить током при нанесении урона по ним
