### PR TITLE
fix syndie door & CE, Atmos

### DIFF
--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -30,3 +30,9 @@
   - Chapel
   - Hydroponics
   - Atmospherics
+
+- type: accessGroup
+  id: AllAccessSyndicate
+  tags:
+  - Syndicate
+  - NuclearOperative

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -104,6 +104,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: ClothingHandsGlovesAtmos
 
 - type: entity
   id: LockerEngineerFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -164,7 +164,6 @@
       - id: ClothingEyesGlassesMeson
       - id: ClothingBeltChiefEngineerFilled
       - id: ClothingHeadHatBeretEngineering
-      - id: ClothingHandsGlovesColorYellow
       - id: CigarCase
         prob: 0.15
       - id: DoorRemoteEngineering

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -171,6 +171,7 @@
       - id: RubberStampCE
       - id: ClothingHeadsetAltEngineering
       - id: BoxEncryptionKeyEngineering
+      - id: ClothingHandsGlovesCE
 
 - type: entity
   id: LockerChiefMedicalOfficerFilledHardsuit

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -33,6 +33,7 @@
   - type: Access
     groups:
     - AllAccess
+    - AllAccessSyndicate
   - type: UserInterface
     interfaces:
       - key: enum.SolarControlConsoleUiKey.Key


### PR DESCRIPTION
## О запросе слияния
<!-- Что изменено? На какие вещи это может повлиять? -->
Двери синдиката теперь открываются с агоста, в шкафчиках СЕ и атмоса теперь лежат нормальные перчатки (Продвинутые изолированные перчатки и атмосферные спасательные перчатки соответственно)

**Медиа**
<!-- 
Запросы слияния, которые вносят внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), должны содержать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не требуют медиа.

Если Вы не уверены в том, что Ваш запрос слияния требует медиа, спросите мейнтейнера.

Отметьте поле ниже, чтобы подтвердить, что Вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [ ] Я добавил скриншоты/видео к этому запросу слияния, демонстрирующие его изменения в игре, **или** этот запрос слияния не требует демонстрации в игре

**Чейнджлог**
<!--
Здесь Вы можете заполнить журнал изменений, который будет автоматически добавлен в игру при слиянии Вашего запроса на слияние.

Вносите в журнал изменений только те изменения, которые заметны и важны для игрока.

Не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров

Помещение имени после символа :cl: изменит имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub).
Например: :cl: AruMoon
-->

:cl:
- fix: Федерация Магов дала открывашки от дверей синдиката для админ призраков. В шкафах СЕ и Атмостеха снова лежат нормальные перчатки 
