### PR TITLE
Return lead to batteries

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -25,6 +25,8 @@
       reagents:
         - ReagentId: Lithium
           Quantity: 15
+        - ReagentId: Lead
+          Qunatity: 5
   - type: Tag
     tags:
       - DroneUsable


### PR DESCRIPTION
## О запросе слияния
<!-- Что вы изменили в этом Запросе на Слияние? -->
Вернул свинец, так как до гетто химии он был там вместо лития и после его замены его было невозможно нигде взять.
No cl
