### PR TITLE
Кошки теперь милее

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
@@ -31,10 +31,6 @@
       - !type:WashCreamPieReaction
       - !type:CancelDoAfters
   - type: NyaAccent
-  - type: Sprite
-    noRot: true
-    drawdepth: Mobs
-    scale: 1, 0.9
 
 - type: entity
   name: Urist McHands

--- a/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/felinid.yml
@@ -30,6 +30,11 @@
       effects:
       - !type:WashCreamPieReaction
       - !type:CancelDoAfters
+  - type: NyaAccent
+  - type: Sprite
+    noRot: true
+    drawdepth: Mobs
+    scale: 1, 0.9
 
 - type: entity
   name: Urist McHands


### PR DESCRIPTION
## О запросе слияния

Фелиниды теперь используют акцент кошек по умолчанию. Стали чуть ниже обычного человека.

## Почему / Баланс

Слаймы, унатхи имеют свой особенный акцент, а фелиниды нет... Делаем игру более насыщенной и изменяем их рост (Незначительно). И люди уже давненько поднимали данную тему в хотелках.

## Медиа

- [X] Я добавил скриншоты/видео к этому запросу слияния, демонстрирующие его изменения в игре, **или** этот запрос слияния не требует демонстрации в игре

**Чейнджлог**

:cl: Pingva
:new: Meow!
