### PR TITLE
Bluespace orebags fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -31,6 +31,7 @@
   parent: BaseStorageItem
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore.
   components:
+  - type: MagnetPickup
   - type: Sprite
     sprite: Objects/Specific/Mining/ore_bag_bluespace.rsi
     state: icon
@@ -46,7 +47,7 @@
   - type: Item
     size: 176
   - type: Storage
-    capacity: 2400
+    capacity: 9999
     quickInsert: true
     areaInsert: true
     areaInsertRadius: 14


### PR DESCRIPTION
## О запросе слияния
Добавлен компонент MagnetPickup для блюспейс мешка для руды. Увеличена вместимость мешка (У других блюспейс хранилищ вместимость 9999. Чем сумка для руды хуже?).


**Чейнджлог**

:cl: Quartug
- fix: Блюспейс мешок для руды теперь поднимает руду с пола.
