### PR TITLE
Security Access support on alert + No more lawyer-traitors

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderBoardSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderBoardSystem.cs
@@ -70,9 +70,9 @@ namespace Content.Shared.Access.Systems
                             ClearAlertLevelAccess(accessStorage);
                             accessStorage.AccessLists.Add(new HashSet<string>() { "Engineering" });
                             break;
-                        case "red":
+                        case "red" or "gamma" or "delta":
                             ClearAlertLevelAccess(accessStorage);
-                            accessStorage.AccessLists.Add(new HashSet<string>() { "Brig" });
+                            accessStorage.AccessLists.Add(new HashSet<string>() { "Security" });
                             break;
                         default:
                             ClearAlertLevelAccess(accessStorage);

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -10,6 +10,7 @@
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-hop
+  canBeAntag: false
   access:
   - Service
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -10,7 +10,6 @@
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-hop
-  canBeAntag: false
   access:
   - Service
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Command/blueshield.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/blueshield.yml
@@ -26,6 +26,7 @@
   - Command
   - Medical
   - Engineering
+  - Maintenance
   - External
   - Security
   - Brig


### PR DESCRIPTION
## О запросе слияния
1. Служба безопасности впредь будет получать все доступы не только в `Красный` код, но и в коды `Гамма` и `Дельта`.
2. Также Адвокат более не сможет получить полный доступ в описанные выше коды, так как фильтр по доступу сменился с `Бриг` на `СлужбаБезопасности`.

## Почему / Баланс
1. Во время критических событий, когда устанавливается Гамма код и при запуске Ядерное боеголовки в код Дельта, сотрудники службы безопасности были вынуждены просить доступ/открыть двери главой/сотрудником отдела, теряя драгоценное время, необходимое для устранения угрозы.
2. Игроки привыкли брать Адвоката не с целью самой роли - помогать заключённым при вынесении несправедливых сроков и заключений, а с целью выбивания Предателя на этой роли и вместе с этим получением полного доступа во все отделы, что, делало из Адвоката ультимативного Предателя (или идеальную добычу для Предателей).

**Чейнджлог**

:cl:
- tweak: После нескольких поправок в блюспейс-ретрансляторе, члены отдела Службы Безопасности отныне также получают доступ в отделы в коды Гамма и Дельта.
- tweak: Адвокаты больше не получают доступов в отделы в Красный, Гамма и Дельта коды.
