### PR TITLE
Small fix and rad injector craft

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -148,7 +148,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 15
+          min: 16
         damage:
           types:
             Asphyxiation: 0.5
@@ -161,7 +161,7 @@
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 15
+          min: 16
     Alcohol:
       effects:
       - !type:Drunk
@@ -235,7 +235,7 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10
+          min: 11
         damage:
           types:
             Asphyxiation: 1
@@ -245,7 +245,7 @@
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 10
+          min: 11
 
 - type: reagent
   id: Dexalin

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1740,6 +1740,17 @@
     Leporazine: 5
 
 - type: microwaveMealRecipe
+  id: RecipeRadAutoInjector
+  name: Brute auto injector recipe
+  result: RadAutoInjector
+  time: 5
+  solids:
+    Syringe: 1
+  reagents:
+    Bicaridine: 5
+    Arithrazine: 10
+
+- type: microwaveMealRecipe
   id: RecipeBruteAutoInjector
   name: Brute auto injector recipe
   result: BruteAutoInjector


### PR DESCRIPTION
## О запросе слияния
Добавлен крафт медпена против радиации, изменено условие передозировки бикаридина и дермалина

## Почему / Баланс
В учебнике указано, что передозировка наступает при принятии >15u и >10u для бикаридина и дермалина соответственно. В коде условие стояло >=15 и >=10

:cl:
- add: Добавлен крафт медпена радиации. 5 бикаридина, 10 аритризина, шприц в микроволновке на 5 сек.
- fix: Исправлена передозировка бикаридина и дермалина.
