### PR TITLE
Welding mask nerf

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -4,6 +4,7 @@
   name: welding mask
   abstract: true
   components:
+  - type: Blindfold
   - type: IngestionBlocker
   - type: FlashImmunity
   - type: IdentityBlocker


### PR DESCRIPTION
## О запросе слияния
Сварочная маска ограничивает радиус обзора, когда находится на персонаже.

## Почему / Баланс
Сварочная маска дает неоправданно сильные преимущества. Защита от флешек и сварки, когда она буквально находится в техах на каждом углу. Теперь, когда она на персонаже, он все ещё получает эти преимущества, но не видит ничего вокруг. А ещё на тг точно так же.

:cl:
- fix: Исправлена сварочная маска. Теперь обзор урезается во время ношения.
