### PR TITLE
Hardsuit heat protection update

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -152,6 +152,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
+        Heat: 0.9
         Radiation: 0.3 #salv is supposed to have radiation hazards in the future
         Caustic: 0.8
   - type: ClothingSpeedModifier
@@ -212,6 +213,7 @@
         Blunt: 0.7
         Slash: 0.7
         Piercing: 0.5
+        Heat: 0.8
         Radiation: 0.3
         Caustic: 0.7
   - type: ClothingSpeedModifier
@@ -242,6 +244,7 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
+        Heat: 0.75
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
@@ -269,6 +272,7 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.7
+        Heat: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -297,6 +301,7 @@
         Blunt: 0.5
         Slash: 0.6
         Piercing: 0.6
+        Heat: 0.7
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.7
@@ -386,6 +391,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Heat: 0.9
         Caustic: 0.1
   - type: ClothingSpeedModifier
     walkModifier: 0.9
@@ -454,6 +460,7 @@
         Blunt: 0.6
         Slash: 0.5
         Piercing: 0.5
+        Heat: 0.6
         Radiation: 0.5
         Caustic: 0.6
   - type: ClothingSpeedModifier
@@ -484,6 +491,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.8
+        Heat: 0.7
         Radiation: 0.5
         Caustic: 0.8
   - type: ClothingSpeedModifier


### PR DESCRIPTION
Была возвращена защита от огня для многих скафандров: скафандр СБ (25%); скафандр бригмедика (20%); скафандр смотрителя (30%); скафандр ГСБ (40%); скафандр ГВ (10%); лёгкий скафандр утилизатора (10%); скафандр утилизатора (20%); роскошный скафандр утилизатора (30%).

- add: Была возвращена защита от огня для многих скафандров.
