### PR TITLE
MK 68 for warden

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -35,7 +35,7 @@
     id: WardenPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
-    pocket1: WeaponPistolMk58Nonlethal
+    pocket1: WeaponPistolMk68
   innerClothingSkirt: ClothingUniformJumpskirtWarden
   satchel: ClothingBackpackSatchelSecurityFilled
   duffelbag: ClothingBackpackDuffelSecurityFilled


### PR DESCRIPTION
Мменяет у смотрителя стандартный МК58 на МК68.

## О запросе слияния
меняет у смотрителя стандартный МК58 на МК68.

## Почему / Баланс
На мой взгляд, смотритель, как старший по бригу и в принципе офицер высокого ранга, должен иметь более продвинутое оружие. МК68 идеально подходит на эту роль, тем более это оружие нигде не используется.

- tweak: Вместо МК58 у смотрителя теперь МК68.