### PR TITLE
Fix Bandolier's capacity

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -437,6 +437,7 @@
   - type: Item
     size: Huge
   - type: Storage
+    maxSlots: 36
     whitelist:
       tags:
         - ShellShotgun


### PR DESCRIPTION
Из-за изменения системы инвентаря бандероль стала бесполезной, так как в неё помещалось всего 7 патронов. Данный апдейт увеличивает вместимость бандероли до 36.

## О запросе слияния
Я увеличил вмещаемость для бандероли с 7 до 36 патронов.
## Почему / Баланс

Причиной тому стала бесполезность бандероли. Раньше бармены и други игроки с удовольствием использовали бандерольки, так как они позволяли хранить большой боезапас не занимая места в сумке. Сейчас же из-за изменения системы инвентаря бандероли стали бесполезными, так как вмещают всего 7 патронов.

:cl:
- fix: Исправлена вместимость бандольера.