### PR TITLE
Remove atlas from map pull

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -2,7 +2,6 @@
   id: DefaultMapPool
   maps:
   - Aspid
-  - Atlas
   - Bagel
   - Box
   - Cluster


### PR DESCRIPTION
## О запросе слияния
В этом ПРе я внес очень важные изменения, а именно: удалил из пулла карт рассадник похоти, ненависти к человечеству, **НЕ** великую и крайне ужасную карту - Atlas.

## Почему / Баланс
Эта карта не должна была существовать. Мало того, что она имеет крайне не приятную для глаза визуальную составляющую (Коридоры - пусты), так ещё наполнена различными багами (Чего только стоит камера в СБ.
Эту карту вообще проверяли перед тем как её принять?). Станция не может продержаться на одном лишь ДАМе, ей нужен РИТЭГ и солнечные панели. И не дай, о, великий Господь всея живого, чтобы хоть один из этих источников повредился...
Ну а ещё она просто никому не нравится. Кому вообще может нравиться карта, на которой 2 газодобытчика? 

## Техническая информация
Атлас был удален из default.yml (Отвечает за возможность карты появиться в игре)

**Чейнджлог**

:cl:

- remove: Станция Atlas больше не может появиться как игровая станция.


