### PR TITLE
Blueshield's nerf

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -94,7 +94,11 @@
   components:
   - type: StorageFill
     contents:
-      - id: MysteryWeaponBox
+      - id: MagazinePistolSubMachineGun
+      - id: MagazinePistolSubMachineGun
+      - id: MagazineMagnum
+      - id: WeaponPistolN1984
+      - id: WeaponSubMachineGunAtreides
       - id: MedkitCombatFilled
       - id: Handcuffs
       - id: Flash
@@ -103,6 +107,7 @@
       - id: ClothingHeadsetAltBlueShield
       - id: ClothingHeadsetBlueShield
       - id: WoodenMedalCase
+      - id: ClothingOuterHardsuitERTBlueShield
 
 - type: entity
   id: LockerCaptainFilled

--- a/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -63,7 +63,7 @@
 
 # BlueShield Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitSyndie
+  parent: ClothingOuterHardsuitSecurity
   id: ClothingOuterHardsuitERTBlueShield
   name: ERT security's hardsuit
   components:
@@ -73,6 +73,9 @@
     sprite: Starshine/Clothing/OuterClothing/Hardsuits/blueshield.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTBlueShield
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
 
 #Chrono Legionnaire Hardsuit
 - type: entity


### PR DESCRIPTION
Серьёзный нёрф офицера синего щита. Во первых, теперь его скафандр равен по статам скафандру офицера сб, однако более быстрый. Во вторых, было заменено оружие у бщ: теперь это пп атрейдес и пистолет N1984.

:cl:
- tweak: Вооружение офицера синего щита было заменено Атрейдесом и пистолетом N1984.
- tweak: Показатели брони скафандра офицера синего щита были снижены до показателей скафандра офицера сб, за тем исключением, что теперь он замедляет на 10%.
