### PR TITLE
Исправление бага с шахтёрской бронёй.

### DIFF
--- a/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/armor.yml
@@ -97,6 +97,9 @@
         Piercing: 0.40
         Heat: 0.40
         Caustic: 0.55
+  - type: Tag
+    tags:
+    - SyndieMinerArmorHeavy
   - type: Construction
     graph: ArmorSyndieMinerHeavy
     node: armorsyndieminerheavy
@@ -123,6 +126,9 @@
         Piercing: 0.65
         Heat: 0.55
         Caustic: 0.55
+  - type: Tag
+    tags:
+    - MinerArmorHeavy
   - type: Construction
     graph: ArmorMinerHeavy
     node: armorminerheavy
@@ -147,6 +153,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.2
     sprintModifier: 1.2
+  - type: Tag
+    tags:
+    - SyndieMinerArmorLight
   - type: Construction
     graph: ArmorSyndieMinerLight
     node: armorsyndieminerlight
@@ -171,6 +180,9 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.2
     sprintModifier: 1.2
+  - type: Tag
+    tags:
+    - MinerArmorLight
   - type: Construction
     graph: ArmorMinerLight
     node: armorminerlight

--- a/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Starshine/Entities/Clothing/OuterClothing/armor.yml
@@ -19,10 +19,13 @@
   - type: ExplosionResistance
     damageCoefficient: 0.80
 
+# Miner Armor
+
 - type: entity
   parent: ClothingOuterArmorBase
-  id: ClothingOuterArmorMiner
+  id: ClothingOuterArmorMinerBase
   name: bulletproof vest
+  abstract: true
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
   components:
   - type: Sprite
@@ -40,17 +43,15 @@
     damageCoefficient: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetMiner
-  - type: Tag
-    tags:
-    - MinerArmor
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
 
 - type: entity
   parent: ClothingOuterArmorBase
-  id: ClothingOuterArmorMinerSyndie
+  id: ClothingOuterSyndieArmorMinerBase
   name: bulletproof vest
+  abstract: true
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
   components:
   - type: Sprite
@@ -68,15 +69,50 @@
     damageCoefficient: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetMinerSyndie
-  - type: Tag
-    tags:
-    - SyndieMinerArmor
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
 
 - type: entity
-  parent: ClothingOuterArmorMinerSyndie
+  parent: ClothingOuterArmorMinerBase
+  id: ClothingOuterArmorMiner
+  name: bulletproof vest
+  description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.85
+        Heat: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
+  - type: Tag
+    tags:
+    - MinerArmor
+
+- type: entity
+  parent: ClothingOuterSyndieArmorMinerBase
+  id: ClothingOuterArmorMinerSyndie
+  name: bulletproof vest
+  description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.60
+        Heat: 0.60
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
+  - type: Tag
+    tags:
+    - SyndieMinerArmor
+
+- type: entity
+  parent: ClothingOuterSyndieArmorMinerBase
   id: ClothingOuterArmorMinerSyndieHeavy
   name: bulletproof vest
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
@@ -97,15 +133,12 @@
         Piercing: 0.40
         Heat: 0.40
         Caustic: 0.55
-  - type: Tag
-    tags:
-    - SyndieMinerArmorHeavy
   - type: Construction
     graph: ArmorSyndieMinerHeavy
     node: armorsyndieminerheavy
 
 - type: entity
-  parent: ClothingOuterArmorMiner
+  parent: ClothingOuterArmorMinerBase
   id: ClothingOuterArmorMinerHeavy
   name: bulletproof vest
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
@@ -126,15 +159,12 @@
         Piercing: 0.65
         Heat: 0.55
         Caustic: 0.55
-  - type: Tag
-    tags:
-    - MinerArmorHeavy
   - type: Construction
     graph: ArmorMinerHeavy
     node: armorminerheavy
 
 - type: entity
-  parent: ClothingOuterArmorMinerSyndie
+  parent: ClothingOuterArmorMinerBase
   id: ClothingOuterArmorMinerSyndieLight
   name: bulletproof vest
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
@@ -153,15 +183,12 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.2
     sprintModifier: 1.2
-  - type: Tag
-    tags:
-    - SyndieMinerArmorLight
   - type: Construction
     graph: ArmorSyndieMinerLight
     node: armorsyndieminerlight
 
 - type: entity
-  parent: ClothingOuterArmorMiner
+  parent: ClothingOuterSyndieArmorMinerBase
   id: ClothingOuterArmorMinerLight
   name: bulletproof vest
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
@@ -180,9 +207,6 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.2
     sprintModifier: 1.2
-  - type: Tag
-    tags:
-    - MinerArmorLight
   - type: Construction
     graph: ArmorMinerLight
     node: armorminerlight

--- a/Resources/Prototypes/Starshine/tags.yml
+++ b/Resources/Prototypes/Starshine/tags.yml
@@ -106,6 +106,18 @@
   id: GygaxArmor
 
 - type: Tag
+  id: MinerArmorLight
+
+- type: Tag
+  id: MinerArmorHeavy
+
+- type: Tag
+  id: SyndieMinerArmorLight
+
+- type: Tag
+  id: SyndieMinerArmorHeavy
+
+- type: Tag
   id: SawElectric
 
 - type: Tag

--- a/Resources/Prototypes/Starshine/tags.yml
+++ b/Resources/Prototypes/Starshine/tags.yml
@@ -106,18 +106,6 @@
   id: GygaxArmor
 
 - type: Tag
-  id: MinerArmorLight
-
-- type: Tag
-  id: MinerArmorHeavy
-
-- type: Tag
-  id: SyndieMinerArmorLight
-
-- type: Tag
-  id: SyndieMinerArmorHeavy
-
-- type: Tag
   id: SawElectric
 
 - type: Tag


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## О запросе слияния
<!-- Что вы изменили? -->
Теперь у шахтёрских броней своя отдельная база.
## Почему / Баланс
<!-- Обсудите, как это повлияет на игровой баланс, или объясните, почему это было изменено. Укажите ссылки на любые относящиеся к этому PR'у обсуждения (discussions) или проблемы (issues). -->
Теперь шахтёрскую броню нельзя "перезаписать". (Пример: До этого ПРа лёгкую броню можно было переделать в тяжелую и наоборот; Лёгкую броню можно было сделать " опять"  из  уже готовой лёгкой брони)

## Требования
<!-- Подтвердите следующие действия, поставив X в скобках [X]: -->
- [X] Я прочитал и следую [Руководству по созданию Запросов на слияние и Чейнджлогов](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил медиа в этот PR, или для этого не требуется игровая демонстрация.
<!-- Вы должны понимать, что несоблюдение вышеперечисленного может привести к закрытию вашего PR'а по усмотрению мейнтейнера. -->
:cl:
- fix: Исправлен баг с шахтёрской бронёй.

