### PR TITLE
No wizards for lowpop?

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -259,7 +259,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 20
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -270,7 +270,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 20
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## О запросе слияния
<!-- Что вы изменили? -->
Теперь маг может появиться от 20+ игроков, а не от 10+.

## Почему / Баланс
<!-- Обсудите, как это повлияет на игровой баланс, или объясните, почему это было изменено. Укажите ссылки на любые относящиеся к этому PR'у обсуждения (discussions) или проблемы (issues). -->
Маг на 10+ онлайна не кайф, ибо даже нюкер не имеет столько эскейпов, возможности насрать и вообще, чаще всего, нюкер убивает при помощи пуль, которые можно вылечить. А вот после гиба собраться уже не получится. 
